### PR TITLE
Fix inconsistent DB path usage

### DIFF
--- a/EasyForce/data_mangement/read_db.py
+++ b/EasyForce/data_mangement/read_db.py
@@ -7,7 +7,8 @@ def display_table(table_name):
     """Display the contents of a specified table, printing first the tuple of column names
     in their creation order, then each row in that same order."""
 
-    database_name = 'my_database.db'
+    # Use the common DB path so that all components operate on the same file
+    database_name = DB_PATH
     conn = None
     try:
         conn = sqlite3.connect(database_name)
@@ -54,7 +55,8 @@ def get_primary_key_val_by_unique_column_val(table, unique_text_value):
     Returns:
         int or None: The primary key of the record if found, or None if no matching record exists.
     """
-    database_name = 'my_database.db'
+    # Use the same database path as the rest of the application
+    database_name = DB_PATH
 
     # Get the primary key column(s) and unique column name
     primary_key_column = get_primary_key_column_names(table)
@@ -148,7 +150,8 @@ def get_unique_column_name(table):
     if table in ("SoldierRole", "Presence", "TaskRole"):
         return None
 
-    database_name = 'my_database.db'
+    # Use the shared database path constant
+    database_name = DB_PATH
     try:
         with sqlite3.connect(database_name) as conn:
             cursor = conn.cursor()


### PR DESCRIPTION
## Summary
- ensure `read_db` consistently uses `DB_PATH` instead of a hardcoded path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f8f632e848328902b90d5fb70734f