### PR TITLE
Fix docstring for missing columns

### DIFF
--- a/EasyForce/data_mangement/data_structure/data_modification.py
+++ b/EasyForce/data_mangement/data_structure/data_modification.py
@@ -119,8 +119,8 @@ class BaseEntity:
             column_name (str): The name of the column to retrieve values from.
 
         Returns:
-            list: A list of values from the specified column if it exists and contains values.
-            None: If the column doesn't exist or contains no values.
+            list: A list of values from the specified column. Returns an empty
+            list when the column is missing or contains no rows.
         """
         table_name = cls.get_table_name()
         columns = cls.get_columns()


### PR DESCRIPTION
## Summary
- clarify that `get_column_values` returns an empty list when the column is missing or empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f97032ad48328ab254005bc20657c